### PR TITLE
Proj ui tweaks

### DIFF
--- a/js/base-project.js
+++ b/js/base-project.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
     $("#project").addClass("current-view");
-    
+    var currentTree = undefined
     var querystring = {}
     /* Naive querystring ?a=1&b=c --> {a:1, b:'c'} mapping */
     if (window.location.search) {
@@ -13,15 +13,20 @@ $(document).ready(function() {
             querystring[name] = value
         }
     }
+    $("#matches").click(evt => {
+        Dataset.loadDefault(setUpMap)
+    })
+
+    function setUpMap(set) {
+        window.components.taxonomyLayoutModal(set,currentTree)
+    }
     
-    console.log('dataset')
 	Dataset.loadDefault(data => {
-        console.log(data)
 	    if (!querystring.p) return
 		api.v1.project.taxonomy(querystring.p).then(serp => {
 			var baseTaxonomyData = serp
             var taxonomy = new window.Taxonomy(serp.taxonomy)
-            console.log(baseTaxonomyData, taxonomy)
+            currentTree = taxonomy
 			window.project.renderGraph('#taxonomy', data, taxonomy, taxonomy.root,[baseTaxonomyData])
 		})
 	})

--- a/js/collection/taxonomy.js
+++ b/js/collection/taxonomy.js
@@ -51,7 +51,7 @@ $(function () {
 		Dataset.loadCollection(cID, setUpMap)
     })
 
-    function setUpMap(set, taxonomy) {
+    function setUpMap(set) {
     	window.components.taxonomyLayoutModal(set,currentTree)
     }
 

--- a/js/project.js
+++ b/js/project.js
@@ -455,8 +455,10 @@ $(function () {
 				document.getElementById('facetName').innerText = name	
 			else
 				document.getElementById('facetName').innerText = name.substring(0,12)+"...";
-			svg.select("#text"+name)
-				.style("fill", '#FFFB00')
+			if(d.name!='root'){
+				svg.select("#text"+name)
+					.style("fill", '#FFFB00')
+			}
 		}
 		function relativeDepth(d){
 			return d.depth - tier
@@ -541,7 +543,8 @@ $(function () {
 					toggleMouseEvents(d, false)
 				})
 			}
-			if(d.name=='root')
+			//can extend from root in proj ui
+			if(d.name=='root' && cID)
 				return
 			svg.selectAll("text")
 				.style("stroke", 'none')

--- a/js/project.js
+++ b/js/project.js
@@ -335,10 +335,17 @@ $(function () {
 	    	var isBase = baseTaxonomyData.taxonomy.some(el=>{
 	    		return head.short.toLowerCase() == el.id.toLowerCase()
 	    	})
-	    	if(isBase){ //prevents base taxonomy being removed
+	    	//if in project editor, you can't remove the root node \
+	    	if( head.short.toLowerCase()== 'root' && querystring.p){ 
 				complain(errorDiv, "Cannot remove Base Taxonomy")
 				return
 			}
+			//if in collection editor you can't remove any base taxonomy nodes
+	    	else if(isBase && cID){ 
+				complain(errorDiv, "Cannot remove Base Taxonomy")
+				return
+			}
+			//remove children of node head
 			var children = head.tree
 			if ( children && children.length > 0 ) {
 				while(children.length > 0){
@@ -354,8 +361,8 @@ $(function () {
 			removeEvents()
 			removeSvg()
 			project.renderGraph('#taxonomy', dataset, taxonomy, serp,[baseTaxonomyData, extendedTaxonomyData])
-			$("#path"+head.parent.toLowerCase()).d3Click()
 			clearInputText()
+			$("#path"+head.parent.toLowerCase()).d3Click()
 			//Clear operations list otherwise will give error. undo button works up until last remove sequence.
 			operations = []
 	    }


### PR DESCRIPTION
947b84f - Changed the base-proj-ui taxonomy editor so that you can remove all nodes except 'root'. When you remove from a node up from root it clicks on root node.

3c3a5f7 - Admins can add a node from anywhere, before it was based off the 'serp' base project taxonomy, but afaik it's intended that an admin can add a facet to anywhere including root node on the project taxonomy ui interface. 
Perhaps this is unnecessary and admins should only be able to add from nodes other than 'root','intervention,'effect','context' and 'other'.?
Perhaps the same with removing? ^^

ef74f5f - the taxonomy map button wasn't functioning from base-project page, now it should work.